### PR TITLE
feat: add leaflet map and aerodatabox lookup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and insert your RapidAPI Aerodatabox key
+AERODATABOX_KEY=YOUR_RAPIDAPI_KEY_HERE

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+vendor/
+.env

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
+Cotação de voo executivo web app com conversão NM↔KM, múltiplas pernas, mapa Leaflet e lookup de aeroportos via Aerodatabox.
 # Leandro-Almeida
+
+To regenerate the vendored jsdom tarball, run:
+
+```
+npm pack jsdom@24.0.0
+mkdir -p vendor
+mv jsdom-24.0.0.tgz vendor/
+```
+
+
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
@@ -67,6 +78,10 @@
       <input type="number" id="nm" />
     </div>
     <div>
+      <label>Distância (KM):</label>
+      <input type="number" id="km" />
+    </div>
+    <div>
       <label>Origem:</label>
       <input type="text" id="origem" />
     </div>
@@ -115,15 +130,70 @@
       "Cirrus SR22": 15
     };
 
+    document.getElementById('nm').addEventListener('input', (e) => {
+      const val = parseFloat(e.target.value);
+      const kmInput = document.getElementById('km');
+      kmInput.value = Number.isFinite(val) ? (val * 1.852).toFixed(1) : '';
+    });
+
+    document.getElementById('km').addEventListener('input', (e) => {
+      const val = parseFloat(e.target.value);
+      const nmInput = document.getElementById('nm');
+      nmInput.value = Number.isFinite(val) ? (val / 1.852).toFixed(1) : '';
+    });
+
+    let routeLayer = null;
+
+    function haversine(a, b) {
+      const R = 6371; // Earth radius in km
+      const toRad = (deg) => deg * Math.PI / 180;
+      const dLat = toRad(b.lat - a.lat);
+      const dLon = toRad(b.lng - a.lng);
+      const lat1 = toRad(a.lat);
+      const lat2 = toRad(b.lat);
+      const h = Math.sin(dLat / 2) ** 2 +
+                Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+      return 2 * R * Math.asin(Math.sqrt(h));
+    }
+
+    function updateDistanceFromAirports(waypoints) {
+      const nmInput = document.getElementById('nm');
+      const kmInput = document.getElementById('km');
+      const points = (waypoints || []).filter(p => p && Number.isFinite(p.lat) && Number.isFinite(p.lng));
+
+      if (points.length < 2) {
+        if (routeLayer && typeof routeLayer.remove === 'function') {
+          routeLayer.remove();
+        }
+        routeLayer = null;
+        if (nmInput) nmInput.value = '';
+        if (kmInput) kmInput.value = '';
+        return;
+      }
+
+      let kmTotal = 0;
+      for (let i = 1; i < points.length; i++) {
+        kmTotal += haversine(points[i - 1], points[i]);
+      }
+      const nmTotal = kmTotal / 1.852;
+
+      if (nmInput) nmInput.value = nmTotal.toFixed(1);
+      if (kmInput) kmInput.value = kmTotal.toFixed(1);
+
+      if (typeof L !== 'undefined' && typeof map !== 'undefined') {
+        if (routeLayer) routeLayer.remove();
+        routeLayer = L.polyline(points.map(p => [p.lat, p.lng]), { color: 'blue' }).addTo(map);
+      }
+    }
+
     function gerarPreOrcamento() {
       const aeronave = document.getElementById("aeronave").value;
       const nm = parseFloat(document.getElementById("nm").value);
+      const km = parseFloat(document.getElementById("km").value);
       const origem = document.getElementById("origem").value;
       const destino = document.getElementById("destino").value;
       const valorExtra = parseFloat(document.getElementById("valorExtra").value) || 0;
       const tipoExtra = document.getElementById("tipoExtra").value;
-
-      const km = nm * 1.852;
       const valorKm = valoresKm[aeronave];
       let total = km * valorKm;
 
@@ -152,6 +222,7 @@
     function gerarPDF() {
       const aeronave = document.getElementById("aeronave").value;
       const nm = parseFloat(document.getElementById("nm").value);
+      const km = parseFloat(document.getElementById("km").value);
       const origem = document.getElementById("origem").value;
       const destino = document.getElementById("destino").value;
       const dataIda = document.getElementById("dataIda").value;
@@ -161,7 +232,6 @@
       const valorExtra = parseFloat(document.getElementById("valorExtra").value) || 0;
       const tipoExtra = document.getElementById("tipoExtra").value;
 
-      const km = nm * 1.852;
       const valorKm = valoresKm[aeronave];
       let total = km * valorKm;
 

--- a/app.js
+++ b/app.js
@@ -1,0 +1,335 @@
+const valoresKm = {
+  "Hawker 400": 36,
+  "Phenom 100": 36,
+  "Citation II": 36,
+  "King Air C90": 30,
+  "Sêneca IV": 22,
+  "Cirrus SR22": 15
+};
+
+const AERODATABOX_KEY = "84765bd38cmsh03b2568c9aa4a0fp1867f6jsnd28a64117f8b";
+const AERODATABOX_HOST = "aerodatabox.p.rapidapi.com";
+const coordCache = {};
+let map;
+let routeLayer;
+
+function initDistanceSync() {
+  if (typeof document === "undefined") return;
+  const nmInput = document.getElementById("nm");
+  const kmInput = document.getElementById("km");
+  if (!nmInput || !kmInput) return;
+  nmInput.addEventListener("input", () => {
+    const v = parseFloat(nmInput.value);
+    kmInput.value = !isNaN(v) ? (v * 1.852).toFixed(1) : "";
+  });
+  kmInput.addEventListener("input", () => {
+    const v = parseFloat(kmInput.value);
+    nmInput.value = !isNaN(v) ? (v / 1.852).toFixed(1) : "";
+  });
+}
+
+initDistanceSync();
+
+function initTarifaSync() {
+  if (typeof document === "undefined") return;
+  const sel = document.getElementById("aeronave");
+  const tarifaInput = document.getElementById("tarifa");
+  if (!sel || !tarifaInput) return;
+  sel.addEventListener("change", () => {
+    const v = valoresKm[sel.value];
+    tarifaInput.value = v ? v.toFixed(2) : "";
+  });
+}
+
+initTarifaSync();
+
+function addStopField() {
+  const container = document.getElementById("stops");
+  if (!container) return;
+  const input = document.createElement("input");
+  input.type = "text";
+  input.className = "stop-input";
+  container.appendChild(input);
+}
+
+function initStops() {
+  if (typeof document === "undefined") return;
+  const btn = document.getElementById("addStop");
+  if (btn) btn.addEventListener("click", addStopField);
+}
+
+initStops();
+
+function initMap() {
+  if (typeof L === "undefined" || map) return;
+  map = L.map("map").setView([0, 0], 2);
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    attribution: "&copy; OpenStreetMap contributors"
+  }).addTo(map);
+}
+
+async function getCoordinates(icao) {
+  const code = icao.toUpperCase();
+  if (coordCache[code]) return coordCache[code];
+  const resp = await fetch(`https://${AERODATABOX_HOST}/airports/icao/${code}`, {
+    headers: {
+      "X-RapidAPI-Key": AERODATABOX_KEY,
+      "X-RapidAPI-Host": AERODATABOX_HOST
+    }
+  });
+  if (!resp.ok) {
+    throw new Error(`Falha ao buscar ${code}: ${resp.status}`);
+  }
+  const data = await resp.json();
+  coordCache[code] = { lat: data.location.lat, lon: data.location.lon };
+  return coordCache[code];
+}
+
+function toRad(v) { return v * Math.PI / 180; }
+function distanciaKm(a, b) {
+  const R = 6371;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const h = Math.sin(dLat/2)**2 + Math.cos(toRad(a.lat))*Math.cos(toRad(b.lat))*Math.sin(dLon/2)**2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+function drawRouteOnMap(coords) {
+  if (!map || !Array.isArray(coords) || coords.length < 2) return;
+  if (routeLayer) {
+    map.removeLayer(routeLayer);
+    routeLayer = null;
+  }
+  const points = coords.map(c => [c.lat, c.lon]);
+  routeLayer = L.polyline(points, { color: "blue" }).addTo(map);
+  map.fitBounds(routeLayer.getBounds(), { padding: [20, 20] });
+}
+
+function buildFilters() {
+  return {
+    showRota: document.getElementById("showRota").checked,
+    showAeronave: document.getElementById("showAeronave").checked,
+    showTarifa: document.getElementById("showTarifa").checked,
+    showDistancia: document.getElementById("showDistancia").checked,
+    showDatas: document.getElementById("showDatas").checked,
+    showAjuste: document.getElementById("showAjuste").checked,
+    showObservacoes: document.getElementById("showObservacoes").checked,
+    showMapa: document.getElementById("showMapa").checked
+  };
+}
+
+function buildState() {
+  const aeronave = document.getElementById("aeronave").value;
+  let nm = parseFloat(document.getElementById("nm").value);
+  let km = parseFloat(document.getElementById("km").value);
+  if (!isNaN(km) && (isNaN(nm) || nm === 0)) {
+    nm = km / 1.852;
+  } else if (!isNaN(nm) && (isNaN(km) || km === 0)) {
+    km = nm * 1.852;
+  }
+  const origem = document.getElementById("origem").value;
+  const destino = document.getElementById("destino").value;
+  const stops = Array.from(document.querySelectorAll(".stop-input"))
+    .map(i => i.value)
+    .filter(Boolean);
+  const dataIda = document.getElementById("dataIda").value;
+  const dataVolta = document.getElementById("dataVolta").value;
+  const observacoes = document.getElementById("observacoes").value;
+  const incluirNoPDF = document.getElementById("incluirNoPDF").checked;
+  const valorExtra = parseFloat(document.getElementById("valorExtra").value) || 0;
+  const tipoExtra = document.getElementById("tipoExtra").value;
+  const tarifaInput = parseFloat(document.getElementById("tarifa").value);
+  const valorKm = !isNaN(tarifaInput) ? tarifaInput : valoresKm[aeronave];
+  return {
+    aeronave,
+    nm,
+    km,
+    origem,
+    destino,
+    dataIda,
+    dataVolta,
+    observacoes,
+    incluirNoPDF,
+    valorExtra,
+    tipoExtra,
+    valorKm,
+    stops,
+    ...buildFilters()
+  };
+}
+
+async function gerarPreOrcamento(cfg) {
+  cfg = cfg || buildState();
+  let {
+    aeronave,
+    nm,
+    km,
+    origem,
+    destino,
+    stops,
+    dataIda,
+    dataVolta,
+    observacoes,
+    valorExtra,
+    tipoExtra,
+    valorKm
+  } = cfg;
+
+  const waypoints = [origem, ...(stops || []), destino].filter(Boolean);
+  let coords = [];
+  if ((isNaN(nm) && isNaN(km)) && waypoints.length >= 2) {
+    km = 0;
+    for (const code of waypoints) {
+      const c = await getCoordinates(code);
+      coords.push(c);
+      if (coords.length > 1) {
+        km += distanciaKm(coords[coords.length - 2], c);
+      }
+    }
+    nm = km / 1.852;
+  } else {
+    for (const code of waypoints) {
+      try {
+        const c = await getCoordinates(code);
+        coords.push(c);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    if ((isNaN(nm) || !nm) && !isNaN(km)) {
+      nm = km / 1.852;
+    } else {
+      km = nm * 1.852;
+    }
+  }
+
+  if (typeof document !== 'undefined') {
+    const nmEl = document.getElementById("nm");
+    const kmEl = document.getElementById("km");
+    if (nmEl) nmEl.value = nm ? nm.toFixed(1) : "";
+    if (kmEl) kmEl.value = km ? km.toFixed(1) : "";
+  }
+
+  const tarifa = !isNaN(valorKm) ? valorKm : valoresKm[aeronave];
+  let total = km * tarifa;
+  let labelExtra = "";
+  if (valorExtra > 0) {
+    if (tipoExtra === "soma") {
+      total += valorExtra;
+      labelExtra = `+ R$ ${valorExtra.toLocaleString('pt-BR', { minimumFractionDigits: 2 })} (outras despesas)`;
+    } else {
+      total -= valorExtra;
+      labelExtra = `- R$ ${valorExtra.toLocaleString('pt-BR', { minimumFractionDigits: 2 })} (desconto)`;
+    }
+  }
+  let html = `<h3>Pré-Orçamento</h3>`;
+  if (cfg.showRota) {
+    html += `<p><strong>Rota:</strong> ${waypoints.join(' → ')}</p>`;
+  }
+  if (cfg.showAeronave) {
+    html += `<p><strong>Aeronave:</strong> ${aeronave}</p>`;
+  }
+  if (cfg.showDistancia) {
+    html += `<p><strong>Distância:</strong> ${nm.toFixed(1)} NM (${km.toFixed(1)} km)</p>`;
+  }
+  if (cfg.showDatas) {
+    html += `<p><strong>Datas:</strong> ${dataIda} - ${dataVolta}</p>`;
+  }
+  if (cfg.showAjuste && labelExtra) {
+    html += `<p><strong>Ajuste:</strong> ${labelExtra}</p>`;
+  }
+  if (cfg.showObservacoes && observacoes) {
+    html += `<p><strong>Observações:</strong> ${observacoes}</p>`;
+  }
+  if (cfg.showTarifa) {
+    html += `<p><strong>Total Estimado:</strong> R$ ${total.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</p>`;
+  }
+  if (cfg.showMapa) {
+    html += `<div id="mapa"></div>`;
+  }
+  if (typeof document !== 'undefined') {
+    document.getElementById("resultado").innerHTML = html;
+    if (cfg.showMapa && coords.length >= 2) {
+      initMap();
+      drawRouteOnMap(coords);
+    }
+  }
+  return html;
+}
+
+function buildDocDefinition(cfg) {
+  const {
+    aeronave,
+    nm,
+    km: kmInput,
+    origem,
+    destino,
+    stops = [],
+    dataIda,
+    dataVolta,
+    observacoes,
+    incluirNoPDF,
+    valorExtra,
+    tipoExtra,
+    valorKm
+  } = cfg;
+  const km = !isNaN(kmInput) ? kmInput : nm * 1.852;
+  const tarifa = !isNaN(valorKm) ? valorKm : valoresKm[aeronave];
+  let total = km * tarifa;
+  let ajustes = null;
+  if (cfg.showAjuste && valorExtra > 0 && incluirNoPDF) {
+    const val = valorExtra.toLocaleString('pt-BR', { minimumFractionDigits: 2 });
+    if (tipoExtra === "soma") {
+      total += valorExtra;
+      ajustes = { text: `Outras Despesas: R$ ${val}`, margin: [0, 10, 0, 0] };
+    } else {
+      total -= valorExtra;
+      ajustes = { text: `Desconto: R$ ${val}`, margin: [0, 10, 0, 0] };
+    }
+  }
+  const rotaStr = [origem, ...stops, destino].filter(Boolean).join(' → ');
+  const content = [
+    { text: "Cotação de Voo Executivo", style: "header" },
+    cfg.showRota ? { text: `Rota: ${rotaStr}`, margin: [0, 10, 0, 0] } : null,
+    cfg.showAeronave ? { text: `Aeronave: ${aeronave}` } : null,
+    cfg.showDatas ? { text: `Datas: ${dataIda} - ${dataVolta}` } : null,
+    cfg.showDistancia ? { text: `Distância: ${nm} NM (${km.toFixed(1)} km)` } : null,
+    ajustes,
+    cfg.showTarifa ? {
+      text: `Total Final: R$ ${total.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`,
+      bold: true,
+      margin: [0, 10, 0, 0]
+    } : null,
+    (cfg.showObservacoes && observacoes) ? { text: `Observações: ${observacoes}`, margin: [0, 10, 0, 0] } : null,
+    cfg.showMapa ? { text: 'Mapa: [não implementado]' } : null
+  ].filter(Boolean);
+  return {
+    content,
+    styles: {
+      header: {
+        fontSize: 18,
+        bold: true
+      }
+    }
+  };
+}
+
+function gerarPDF(cfg) {
+  cfg = cfg || buildState();
+  const docDefinition = buildDocDefinition(cfg);
+  if (typeof pdfMake !== 'undefined' && pdfMake.createPdf) {
+    pdfMake.createPdf(docDefinition).open();
+  }
+  return docDefinition;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    buildFilters,
+    buildState,
+    gerarPreOrcamento,
+    gerarPDF,
+    buildDocDefinition,
+    valoresKm
+  };
+}

--- a/cotacao.js
+++ b/cotacao.js
@@ -1,0 +1,9 @@
+function valorParcial(distanciaKm, valorKm) {
+  return distanciaKm * valorKm;
+}
+
+function valorTotal(distanciaKm, valorKm, valorExtra = 0) {
+  return valorParcial(distanciaKm, valorKm) + valorExtra;
+}
+
+module.exports = { valorParcial, valorTotal };

--- a/index.html
+++ b/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Cotação de Voo Executivo</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
+  <style>
+    body {
+      font-family: 'Arial', sans-serif;
+      margin: 30px;
+      max-width: 800px;
+    }
+    label {
+      font-weight: bold;
+      display: block;
+      margin-top: 15px;
+    }
+    input, select, textarea {
+      width: 100%;
+      padding: 8px;
+      margin-top: 5px;
+    }
+    .linha {
+      display: flex;
+      gap: 10px;
+    }
+    .linha > div {
+      flex: 1;
+    }
+    .botoes {
+      margin-top: 30px;
+    }
+    button {
+      padding: 12px 20px;
+      font-size: 16px;
+      margin-right: 10px;
+      cursor: pointer;
+    }
+    #resultado {
+      margin-top: 30px;
+      border-top: 1px solid #ccc;
+      padding-top: 20px;
+    }
+    #pdfFilters {
+      margin-top: 20px;
+      border: 1px solid #ccc;
+      padding: 10px;
+    }
+    #pdfFilters label {
+      font-weight: normal;
+      display: inline-block;
+      margin-right: 10px;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Cotação de Voo Executivo</h1>
+
+  <label>Aeronave:</label>
+  <select id="aeronave">
+    <option value="" disabled selected>Escolha uma aeronave</option>
+    <option value="Hawker 400">Hawker 400 — R$36,00/km</option>
+    <option value="Phenom 100">Phenom 100 — R$36,00/km</option>
+    <option value="Citation II">Citation II — R$36,00/km</option>
+    <option value="King Air C90">King Air C90 — R$30,00/km</option>
+    <option value="Sêneca IV">Sêneca IV — R$22,00/km</option>
+    <option value="Cirrus SR22">Cirrus SR22 — R$15,00/km</option>
+  </select>
+
+  <label>Tarifa por km (R$):</label>
+  <input type="number" id="tarifa" step="0.01" />
+
+  <div class="linha">
+    <div>
+      <label>Distância (NM):</label>
+      <input type="number" id="nm" />
+    </div>
+    <div>
+      <label>Distância (KM):</label>
+      <input type="number" id="km" />
+    </div>
+    <div>
+      <label>Origem:</label>
+      <input type="text" id="origem" />
+    </div>
+    <div>
+      <label>Destino:</label>
+      <input type="text" id="destino" />
+    </div>
+  </div>
+
+  <div id="stops"></div>
+  <button id="addStop" type="button">Adicionar Aeroporto</button>
+
+  <div class="linha">
+    <div>
+      <label>Data Ida:</label>
+      <input type="date" id="dataIda" />
+    </div>
+    <div>
+      <label>Data Volta:</label>
+      <input type="date" id="dataVolta" />
+    </div>
+  </div>
+
+  <label>Acréscimo ou Desconto:</label>
+  <input type="number" id="valorExtra" placeholder="Valor em R$" />
+  <select id="tipoExtra">
+    <option value="soma">Adicionar</option>
+    <option value="subtrai">Subtrair</option>
+  </select>
+  <label><input type="checkbox" id="incluirNoPDF" /> Incluir no PDF</label>
+
+  <label>Observações:</label>
+  <textarea id="observacoes" rows="4"></textarea>
+
+  <div id="pdfFilters">
+    <h4>Campos do PDF</h4>
+    <label><input type="checkbox" id="showRota" checked /> Rota</label>
+    <label><input type="checkbox" id="showAeronave" checked /> Aeronave</label>
+    <label><input type="checkbox" id="showTarifa" checked /> Tarifa</label>
+    <label><input type="checkbox" id="showDistancia" checked /> Distância</label>
+    <label><input type="checkbox" id="showDatas" checked /> Datas</label>
+    <label><input type="checkbox" id="showAjuste" checked /> Ajuste</label>
+    <label><input type="checkbox" id="showObservacoes" checked /> Observações</label>
+    <label><input type="checkbox" id="showMapa" checked /> Mapa</label>
+  </div>
+
+  <div class="botoes">
+    <button onclick="gerarPreOrcamento()">Gerar Pré-Orçamento</button>
+    <button onclick="gerarPDF()">Gerar PDF</button>
+  </div>
+
+  <div id="resultado"></div>
+
+  <div id="map" style="height: 400px; margin-top: 20px;"></div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "leandro-almeida",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test.js"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,90 @@
+const assert = require('assert');
+const { gerarPDF, buildState, buildDocDefinition } = require('./app.js');
+
+function extractText(docDef) {
+  return docDef.content
+    .filter(item => item && item.text)
+    .map(item => item.text)
+    .join('\n');
+}
+
+const baseState = {
+  aeronave: 'Hawker 400',
+  nm: 100,
+  origem: 'Origem',
+  destino: 'Destino',
+  dataIda: '2024-01-01',
+  dataVolta: '2024-01-02',
+  observacoes: 'Teste',
+  incluirNoPDF: true,
+  valorExtra: 50,
+  tipoExtra: 'soma',
+  valorKm: 36,
+  showRota: true,
+  showAeronave: true,
+  showTarifa: true,
+  showDistancia: true,
+  showDatas: true,
+  showAjuste: true,
+  showObservacoes: true,
+  showMapa: true
+};
+
+const expectations = {
+  showRota: 'Rota:',
+  showAeronave: 'Aeronave:',
+  showTarifa: 'Total Final:',
+  showDistancia: 'Distância:',
+  showDatas: 'Datas:',
+  showAjuste: 'Outras Despesas',
+  showObservacoes: 'Observações:',
+  showMapa: 'Mapa:'
+};
+
+for (const [flag, keyword] of Object.entries(expectations)) {
+  const state = { ...baseState, [flag]: false };
+  const doc = gerarPDF(state);
+  const text = extractText(doc);
+  assert(!text.includes(keyword), `${keyword} should be omitted when ${flag} is false`);
+}
+
+console.log('All filter tests passed.');
+
+// km -> nm conversion via buildState
+const elements = {
+  aeronave: { value: 'Hawker 400' },
+  nm: { value: '' },
+  km: { value: '185.2' },
+  origem: { value: '' },
+  destino: { value: '' },
+  dataIda: { value: '' },
+  dataVolta: { value: '' },
+  observacoes: { value: '' },
+  incluirNoPDF: { checked: false },
+  valorExtra: { value: '0' },
+  tipoExtra: { value: 'soma' },
+  tarifa: { value: '36' },
+  showRota: { checked: true },
+  showAeronave: { checked: true },
+  showTarifa: { checked: true },
+  showDistancia: { checked: true },
+  showDatas: { checked: true },
+  showAjuste: { checked: true },
+  showObservacoes: { checked: true },
+  showMapa: { checked: true }
+};
+global.document = {
+  getElementById: id => elements[id],
+  querySelectorAll: sel => (sel === '.stop-input' ? [{ value: 'SBBH' }] : [])
+};
+const stateConv = buildState();
+assert(Math.abs(stateConv.nm - 100) < 1e-6, 'KM field should convert to NM');
+console.log('KM to NM conversion test passed.');
+assert.deepStrictEqual(stateConv.stops, ['SBBH'], 'Stops should include dynamically added airports');
+console.log('Stops collection test passed.');
+
+// custom tariff affects total
+const customDoc = buildDocDefinition({ ...baseState, valorKm: 50 });
+const textCustom = extractText(customDoc);
+assert(textCustom.includes('R$ 9.310,00'), 'Custom tariff should affect total');
+console.log('Custom tariff test passed.');


### PR DESCRIPTION
## Summary
- embed Leaflet resources and map container to visualize routes
- fetch airport coordinates from Aerodatabox to auto-calc distances and draw polylines
- add editable per-kilometre tariff input that auto-fills from aircraft selection and is used in cost calculations with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0925a8c54832f8350f351d25b4168