### PR TITLE
fix: keep PDF filter checkboxes aligned on mobile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and insert your RapidAPI Aerodatabox key
+AERODATABOX_KEY=YOUR_RAPIDAPI_KEY_HERE

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+vendor/
+.env

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
+Cotação de voo executivo web app com conversão NM↔KM, múltiplas pernas, mapa Leaflet e lookup de aeroportos via Aerodatabox.
 # Leandro-Almeida
+
+To regenerate the vendored jsdom tarball, run:
+
+```
+npm pack jsdom@24.0.0
+mkdir -p vendor
+mv jsdom-24.0.0.tgz vendor/
+```
+
+
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
@@ -67,6 +78,10 @@
       <input type="number" id="nm" />
     </div>
     <div>
+      <label>Distância (KM):</label>
+      <input type="number" id="km" />
+    </div>
+    <div>
       <label>Origem:</label>
       <input type="text" id="origem" />
     </div>
@@ -93,7 +108,13 @@
     <option value="soma">Adicionar</option>
     <option value="subtrai">Subtrair</option>
   </select>
-  <label><input type="checkbox" id="incluirNoPDF" /> Incluir no PDF</label>
+
+  <label>Dados para pagamento:</label>
+  <textarea id="pagamento" rows="5">INTER - 077
+AUTOCON SUPRIMENTOS DE INFORMATICA
+CNPJ: 36.326.772/0001-65
+Agência: 0001
+Conta: 25691815-5</textarea>
 
   <label>Observações:</label>
   <textarea id="observacoes" rows="4"></textarea>
@@ -115,15 +136,70 @@
       "Cirrus SR22": 15
     };
 
+    document.getElementById('nm').addEventListener('input', (e) => {
+      const val = parseFloat(e.target.value);
+      const kmInput = document.getElementById('km');
+      kmInput.value = Number.isFinite(val) ? (val * 1.852).toFixed(1) : '';
+    });
+
+    document.getElementById('km').addEventListener('input', (e) => {
+      const val = parseFloat(e.target.value);
+      const nmInput = document.getElementById('nm');
+      nmInput.value = Number.isFinite(val) ? (val / 1.852).toFixed(1) : '';
+    });
+
+    let routeLayer = null;
+
+    function haversine(a, b) {
+      const R = 6371; // Earth radius in km
+      const toRad = (deg) => deg * Math.PI / 180;
+      const dLat = toRad(b.lat - a.lat);
+      const dLon = toRad(b.lng - a.lng);
+      const lat1 = toRad(a.lat);
+      const lat2 = toRad(b.lat);
+      const h = Math.sin(dLat / 2) ** 2 +
+                Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+      return 2 * R * Math.asin(Math.sqrt(h));
+    }
+
+    function updateDistanceFromAirports(waypoints) {
+      const nmInput = document.getElementById('nm');
+      const kmInput = document.getElementById('km');
+      const points = (waypoints || []).filter(p => p && Number.isFinite(p.lat) && Number.isFinite(p.lng));
+
+      if (points.length < 2) {
+        if (routeLayer && typeof routeLayer.remove === 'function') {
+          routeLayer.remove();
+        }
+        routeLayer = null;
+        if (nmInput) nmInput.value = '';
+        if (kmInput) kmInput.value = '';
+        return;
+      }
+
+      let kmTotal = 0;
+      for (let i = 1; i < points.length; i++) {
+        kmTotal += haversine(points[i - 1], points[i]);
+      }
+      const nmTotal = kmTotal / 1.852;
+
+      if (nmInput) nmInput.value = nmTotal.toFixed(1);
+      if (kmInput) kmInput.value = kmTotal.toFixed(1);
+
+      if (typeof L !== 'undefined' && typeof map !== 'undefined') {
+        if (routeLayer) routeLayer.remove();
+        routeLayer = L.polyline(points.map(p => [p.lat, p.lng]), { color: 'blue' }).addTo(map);
+      }
+    }
+
     function gerarPreOrcamento() {
       const aeronave = document.getElementById("aeronave").value;
       const nm = parseFloat(document.getElementById("nm").value);
+      const km = parseFloat(document.getElementById("km").value);
       const origem = document.getElementById("origem").value;
       const destino = document.getElementById("destino").value;
       const valorExtra = parseFloat(document.getElementById("valorExtra").value) || 0;
       const tipoExtra = document.getElementById("tipoExtra").value;
-
-      const km = nm * 1.852;
       const valorKm = valoresKm[aeronave];
       let total = km * valorKm;
 
@@ -152,21 +228,20 @@
     function gerarPDF() {
       const aeronave = document.getElementById("aeronave").value;
       const nm = parseFloat(document.getElementById("nm").value);
+      const km = parseFloat(document.getElementById("km").value);
       const origem = document.getElementById("origem").value;
       const destino = document.getElementById("destino").value;
       const dataIda = document.getElementById("dataIda").value;
       const dataVolta = document.getElementById("dataVolta").value;
       const observacoes = document.getElementById("observacoes").value;
-      const incluirNoPDF = document.getElementById("incluirNoPDF").checked;
       const valorExtra = parseFloat(document.getElementById("valorExtra").value) || 0;
       const tipoExtra = document.getElementById("tipoExtra").value;
 
-      const km = nm * 1.852;
       const valorKm = valoresKm[aeronave];
       let total = km * valorKm;
 
       let ajustes = "";
-      if (valorExtra > 0 && incluirNoPDF) {
+      if (valorExtra > 0) {
         if (tipoExtra === "soma") {
           total += valorExtra;
           ajustes = { text: `Outras Despesas: R$ ${valorExtra.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`, margin: [0, 10, 0, 0] };

--- a/app.js
+++ b/app.js
@@ -1,0 +1,456 @@
+const valoresKm = {
+  "Hawker 400": 36,
+  "Phenom 100": 36,
+  "Citation II": 36,
+  "King Air C90": 30,
+  "Sêneca IV": 22,
+  "Cirrus SR22": 15
+};
+
+const DEFAULT_PAGAMENTO = `INTER - 077\nAUTOCON SUPRIMENTOS DE INFORMATICA\nCNPJ: 36.326.772/0001-65\nAgência: 0001\nConta: 25691815-5`;
+
+const AERODATABOX_KEY = "84765bd38cmsh03b2568c9aa4a0fp1867f6jsnd28a64117f8b";
+const AERODATABOX_HOST = "aerodatabox.p.rapidapi.com";
+const coordCache = {};
+let map;
+let routeLayer;
+
+function initDistanceSync() {
+  if (typeof document === "undefined") return;
+  const nmInput = document.getElementById("nm");
+  const kmInput = document.getElementById("km");
+  if (!nmInput || !kmInput) return;
+  nmInput.addEventListener("input", () => {
+    const v = parseFloat(nmInput.value);
+    kmInput.value = !isNaN(v) ? (v * 1.852).toFixed(1) : "";
+  });
+  kmInput.addEventListener("input", () => {
+    const v = parseFloat(kmInput.value);
+    nmInput.value = !isNaN(v) ? (v / 1.852).toFixed(1) : "";
+  });
+}
+
+initDistanceSync();
+
+function initTarifaSync() {
+  if (typeof document === "undefined") return;
+  const sel = document.getElementById("aeronave");
+  const tarifaInput = document.getElementById("tarifa");
+  if (!sel || !tarifaInput) return;
+  sel.addEventListener("change", () => {
+    const v = valoresKm[sel.value];
+    tarifaInput.value = v ? v.toFixed(2) : "";
+  });
+}
+
+initTarifaSync();
+
+function addStopField() {
+  const container = document.getElementById("stops");
+  if (!container) return;
+  const input = document.createElement("input");
+  input.type = "text";
+  input.className = "stop-input";
+  container.appendChild(input);
+}
+
+function initStops() {
+  if (typeof document === "undefined") return;
+  const btn = document.getElementById("addStop");
+  if (btn) btn.addEventListener("click", addStopField);
+}
+
+initStops();
+
+function initMap() {
+  if (typeof L === "undefined" || map) return;
+  map = L.map("map", { preferCanvas: true }).setView([0, 0], 2);
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    attribution: "&copy; OpenStreetMap contributors",
+    crossOrigin: true
+  }).addTo(map);
+}
+
+async function getCoordinates(icao) {
+  const code = icao.toUpperCase();
+  if (coordCache[code]) return coordCache[code];
+  const resp = await fetch(`https://${AERODATABOX_HOST}/airports/icao/${code}`, {
+    headers: {
+      "X-RapidAPI-Key": AERODATABOX_KEY,
+      "X-RapidAPI-Host": AERODATABOX_HOST
+    }
+  });
+  if (!resp.ok) {
+    throw new Error(`Falha ao buscar ${code}: ${resp.status}`);
+  }
+  const data = await resp.json();
+  coordCache[code] = { lat: data.location.lat, lon: data.location.lon };
+  return coordCache[code];
+}
+
+function toRad(v) { return v * Math.PI / 180; }
+function distanciaKm(a, b) {
+  const R = 6371;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const h = Math.sin(dLat/2)**2 + Math.cos(toRad(a.lat))*Math.cos(toRad(b.lat))*Math.sin(dLon/2)**2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+function drawRouteOnMap(coords) {
+  if (!map || !Array.isArray(coords) || coords.length < 2) return;
+  if (routeLayer) {
+    map.removeLayer(routeLayer);
+    routeLayer = null;
+  }
+  const points = coords.map(c => [c.lat, c.lon]);
+  routeLayer = L.polyline(points, { color: "blue" }).addTo(map);
+  map.fitBounds(routeLayer.getBounds(), { padding: [20, 20] });
+}
+
+function buildFilters() {
+  return {
+    showRota: document.getElementById("showRota").checked,
+    showAeronave: document.getElementById("showAeronave").checked,
+    showTarifa: document.getElementById("showTarifa").checked,
+    showDistancia: document.getElementById("showDistancia").checked,
+    showDatas: document.getElementById("showDatas").checked,
+    showAjuste: document.getElementById("showAjuste").checked,
+    showObservacoes: document.getElementById("showObservacoes").checked,
+    showPagamento: document.getElementById("showPagamento").checked,
+    showMapa: document.getElementById("showMapa").checked
+  };
+}
+
+function buildState() {
+  const aeronave = document.getElementById("aeronave").value;
+  let nm = parseFloat(document.getElementById("nm").value);
+  let km = parseFloat(document.getElementById("km").value);
+  if (!isNaN(km) && (isNaN(nm) || nm === 0)) {
+    nm = km / 1.852;
+  } else if (!isNaN(nm) && (isNaN(km) || km === 0)) {
+    km = nm * 1.852;
+  }
+  const origem = document.getElementById("origem").value;
+  const destino = document.getElementById("destino").value;
+  const stops = Array.from(document.querySelectorAll(".stop-input"))
+    .map(i => i.value)
+    .filter(Boolean);
+  const dataIda = document.getElementById("dataIda").value;
+  const dataVolta = document.getElementById("dataVolta").value;
+  const observacoes = document.getElementById("observacoes").value;
+  const pagamentoEl = document.getElementById("pagamento");
+  const pagamento = pagamentoEl ? pagamentoEl.value : DEFAULT_PAGAMENTO;
+  const valorExtra = parseFloat(document.getElementById("valorExtra").value) || 0;
+  const tipoExtra = document.getElementById("tipoExtra").value;
+  const tarifaEl = document.getElementById("tarifa");
+  const rawTarifa = tarifaEl ? tarifaEl.value.replace(',', '.') : '';
+  const tarifaNum = parseFloat(rawTarifa);
+  const valorKm = !isNaN(tarifaNum) ? tarifaNum : valoresKm[aeronave];
+  if (tarifaEl) tarifaEl.value = valorKm ? valorKm.toFixed(2) : "";
+  return {
+    aeronave,
+    nm,
+    km,
+    origem,
+    destino,
+    dataIda,
+    dataVolta,
+    observacoes,
+    pagamento,
+    valorExtra,
+    tipoExtra,
+    valorKm,
+    stops,
+    ...buildFilters()
+  };
+}
+
+async function gerarPreOrcamento(cfg) {
+  cfg = cfg || buildState();
+  let {
+    aeronave,
+    nm,
+    km,
+    origem,
+    destino,
+    stops,
+    dataIda,
+    dataVolta,
+    observacoes,
+    pagamento,
+    valorExtra,
+    tipoExtra,
+    valorKm
+  } = cfg;
+
+  const waypoints = [origem, destino, ...(stops || [])].filter(Boolean);
+  let coords = [];
+  if ((isNaN(nm) && isNaN(km)) && waypoints.length >= 2) {
+    km = 0;
+    for (const code of waypoints) {
+      const c = await getCoordinates(code);
+      coords.push(c);
+      if (coords.length > 1) {
+        km += distanciaKm(coords[coords.length - 2], c);
+      }
+    }
+    nm = km / 1.852;
+  } else {
+    for (const code of waypoints) {
+      try {
+        const c = await getCoordinates(code);
+        coords.push(c);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    if ((isNaN(nm) || !nm) && !isNaN(km)) {
+      nm = km / 1.852;
+    } else {
+      km = nm * 1.852;
+    }
+  }
+
+  if (typeof document !== 'undefined') {
+    const nmEl = document.getElementById("nm");
+    const kmEl = document.getElementById("km");
+    if (nmEl) nmEl.value = nm ? nm.toFixed(1) : "";
+    if (kmEl) kmEl.value = km ? km.toFixed(1) : "";
+  }
+
+  const tarifa = !isNaN(valorKm) ? valorKm : valoresKm[aeronave];
+  const parcial = km * tarifa;
+  let total = parcial;
+  let labelExtra = "";
+  if (valorExtra > 0) {
+    if (tipoExtra === "soma") {
+      total += valorExtra;
+      labelExtra = `+ R$ ${valorExtra.toLocaleString('pt-BR', { minimumFractionDigits: 2 })} (outras despesas)`;
+    } else {
+      total -= valorExtra;
+      labelExtra = `- R$ ${valorExtra.toLocaleString('pt-BR', { minimumFractionDigits: 2 })} (desconto)`;
+    }
+  }
+  let html = `<h3>Pré-Orçamento</h3>`;
+  if (cfg.showRota) {
+    html += `<p><strong>Rota:</strong> ${waypoints.join(' → ')}</p>`;
+  }
+  if (cfg.showAeronave) {
+    html += `<p><strong>Aeronave:</strong> ${aeronave}</p>`;
+  }
+  if (cfg.showDistancia) {
+    html += `<p><strong>Distância:</strong> ${nm.toFixed(1)} NM (${km.toFixed(1)} km)</p>`;
+  }
+  if (cfg.showDatas) {
+    html += `<p><strong>Datas:</strong> ${dataIda} - ${dataVolta}</p>`;
+  }
+  html += `<p><strong>Total Parcial:</strong> R$ ${parcial.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</p>`;
+  if (cfg.showAjuste && labelExtra) {
+    html += `<p><strong>Ajuste:</strong> ${labelExtra}</p>`;
+  }
+  if (cfg.showObservacoes && observacoes) {
+    html += `<p><strong>Observações:</strong> ${observacoes}</p>`;
+  }
+  if (cfg.showPagamento && pagamento) {
+    html += `<p><strong>Dados de pagamento:</strong><br>${pagamento.replace(/\n/g, '<br>')}</p>`;
+  }
+  if (cfg.showTarifa) {
+    html += `<p><strong>Tarifa por km:</strong> R$ ${tarifa.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</p>`;
+  }
+  html += `<p><strong>Total Estimado:</strong> R$ ${total.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</p>`;
+  if (cfg.showMapa) {
+    html += `<div id="mapa"></div>`;
+  }
+  if (typeof document !== 'undefined') {
+    document.getElementById("resultado").innerHTML = html;
+    if (cfg.showMapa && coords.length >= 2) {
+      initMap();
+      drawRouteOnMap(coords);
+    }
+  }
+  return html;
+}
+
+function buildDocDefinition(cfg, mapDataUrl) {
+  const {
+    aeronave,
+    nm,
+    km: kmInput,
+    origem,
+    destino,
+    stops = [],
+    dataIda,
+    dataVolta,
+    observacoes,
+    pagamento,
+    valorExtra,
+    tipoExtra,
+    valorKm
+  } = cfg;
+  const km = !isNaN(kmInput) ? kmInput : nm * 1.852;
+  const tarifa = !isNaN(valorKm) ? valorKm : valoresKm[aeronave];
+  const parcial = km * tarifa;
+  let total = parcial;
+  let ajustes = null;
+  if (valorExtra > 0) {
+    const val = valorExtra.toLocaleString('pt-BR', { minimumFractionDigits: 2 });
+    if (tipoExtra === "soma") {
+      total += valorExtra;
+      if (cfg.showAjuste) ajustes = { text: `Outras Despesas: R$ ${val}`, margin: [0, 10, 0, 0] };
+    } else {
+      total -= valorExtra;
+      if (cfg.showAjuste) ajustes = { text: `Desconto: R$ ${val}`, margin: [0, 10, 0, 0] };
+    }
+  }
+  const rotaStr = [origem, destino, ...stops].filter(Boolean).join(' → ');
+  const ajusteText = ajustes ? ajustes.text : null;
+  const tableBody = [
+    cfg.showRota ? [{ text: 'Rota', style: 'label' }, { text: rotaStr, style: 'value' }] : null,
+    cfg.showAeronave ? [{ text: 'Aeronave', style: 'label' }, { text: aeronave, style: 'value' }] : null,
+    cfg.showDatas ? [{ text: 'Datas', style: 'label' }, { text: `${dataIda} - ${dataVolta}`, style: 'value' }] : null,
+    cfg.showDistancia ? [{ text: 'Distância', style: 'label' }, { text: `${nm} NM (${km.toFixed(1)} km)`, style: 'value' }] : null,
+    [{ text: 'Total parcial', style: 'label' }, { text: `R$ ${parcial.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`, style: 'value' }],
+    ajusteText ? [{ text: 'Ajuste', style: 'label' }, { text: ajusteText, style: 'value' }] : null,
+    cfg.showTarifa ? [{ text: 'Tarifa por km', style: 'label' }, { text: `R$ ${tarifa.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`, style: 'value' }] : null,
+    (cfg.showObservacoes && observacoes) ? [{ text: 'Observações', style: 'label' }, { text: observacoes, style: 'value' }] : null,
+    (cfg.showPagamento && pagamento) ? [{ text: 'Dados de pagamento', style: 'label' }, { text: pagamento, style: 'value' }] : null
+  ].filter(Boolean);
+
+  const content = [
+    { text: "Cotação de Voo Executivo", style: "header" },
+    tableBody.length ? { table: { widths: ['auto', '*'], body: tableBody }, layout: 'lightHorizontalLines', margin: [0, 10, 0, 10] } : null,
+    cfg.showMapa ? { text: 'Mapa:', style: 'label', margin: [0, 10, 0, 5] } : null,
+    (cfg.showMapa && mapDataUrl) ? { image: mapDataUrl, width: 500, margin: [0, 0, 0, 10] } : null,
+    (cfg.showMapa && !mapDataUrl) ? { text: '[mapa indisponível]' } : null,
+    { text: `Total Final: R$ ${total.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`, style: 'total' }
+  ].filter(Boolean);
+  return {
+    content,
+    styles: {
+      header: {
+        fontSize: 18,
+        bold: true,
+        alignment: 'center',
+        margin: [0, 0, 0, 10]
+      },
+      label: {
+        bold: true,
+        color: '#555'
+      },
+      value: {},
+      total: {
+        fontSize: 14,
+        bold: true,
+        margin: [0, 10, 0, 0],
+        alignment: 'right'
+      }
+    },
+    defaultStyle: {
+      fontSize: 11
+    }
+  };
+}
+
+async function captureMapImage() {
+  if (typeof html2canvas === 'undefined' || !map) return null;
+  const el = document.getElementById('map');
+  if (!el) return null;
+  try {
+    // give Leaflet a moment to render tiles and fit bounds
+    await new Promise(r => setTimeout(r, 300));
+    // reset map pane transform so overlays align during capture
+    const pane = map.getPanes().mapPane;
+    const prev = pane.style.transform;
+    L.DomUtil.setTransform(pane, L.point(0, 0));
+    const canvas = await html2canvas(el, {
+      useCORS: true,
+      backgroundColor: null
+    });
+    pane.style.transform = prev;
+    return canvas.toDataURL('image/png');
+  } catch (e) {
+    return null;
+  }
+}
+
+async function gerarPDF(cfg) {
+  cfg = cfg || buildState();
+  let mapDataUrl = null;
+  if (cfg.showMapa) {
+    const wp = [cfg.origem, cfg.destino, ...(cfg.stops || [])].filter(Boolean);
+    if (wp.length >= 2) {
+      const coords = await Promise.all(wp.map(getCoordinates));
+      initMap();
+      drawRouteOnMap(coords);
+      try { map.invalidateSize(); } catch (e) {}
+      mapDataUrl = await captureMapImage();
+    }
+  }
+  const docDefinition = buildDocDefinition(cfg, mapDataUrl);
+  if (typeof pdfMake !== 'undefined' && pdfMake.createPdf) {
+    pdfMake.createPdf(docDefinition).open();
+  }
+  return docDefinition;
+}
+
+function limparCampos() {
+  const ids = [
+    "aeronave",
+    "tarifa",
+    "nm",
+    "km",
+    "origem",
+    "destino",
+    "dataIda",
+    "dataVolta",
+    "valorExtra",
+    "observacoes",
+    "pagamento"
+  ];
+  ids.forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.value = "";
+  });
+  const pagEl = document.getElementById("pagamento");
+  if (pagEl) pagEl.value = DEFAULT_PAGAMENTO;
+  const tipoExtra = document.getElementById("tipoExtra");
+  if (tipoExtra) tipoExtra.value = "soma";
+  [
+    "showRota",
+    "showAeronave",
+    "showTarifa",
+    "showDistancia",
+    "showDatas",
+    "showAjuste",
+    "showObservacoes",
+    "showPagamento",
+    "showMapa"
+  ].forEach(id => {
+    const cb = document.getElementById(id);
+    if (cb) cb.checked = true;
+  });
+  const stops = document.getElementById("stops");
+  if (stops) stops.innerHTML = "";
+  const res = document.getElementById("resultado");
+  if (res) res.innerHTML = "";
+  if (routeLayer) {
+    try { routeLayer.remove(); } catch (e) {}
+    routeLayer = null;
+  }
+  if (map) {
+    try { map.setView([0, 0], 2); } catch (e) {}
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    buildFilters,
+    buildState,
+    gerarPreOrcamento,
+    gerarPDF,
+    limparCampos,
+    buildDocDefinition,
+    valoresKm
+  };
+}

--- a/cotacao.js
+++ b/cotacao.js
@@ -1,0 +1,9 @@
+function valorParcial(distanciaKm, valorKm) {
+  return distanciaKm * valorKm;
+}
+
+function valorTotal(distanciaKm, valorKm, valorExtra = 0) {
+  return valorParcial(distanciaKm, valorKm) + valorExtra;
+}
+
+module.exports = { valorParcial, valorTotal };

--- a/index.html
+++ b/index.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Cotação de Voo Executivo</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+  <style>
+    :root {
+      --primary: #0d6efd;
+      --primary-hover: #0b5ed7;
+      --bg: #f8f9fa;
+      --surface: #ffffff;
+      --text: #212529;
+      --border: #ced4da;
+    }
+    *,*::before,*::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Segoe UI', Tahoma, sans-serif;
+    }
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    h1 {
+      text-align: center;
+      margin-bottom: 1.5rem;
+    }
+    label {
+      font-weight: bold;
+      display: block;
+      margin-top: 15px;
+    }
+    input, select, textarea {
+      width: 100%;
+      padding: 8px;
+      margin-top: 5px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--surface);
+    }
+    input:focus,
+    select:focus,
+    textarea:focus {
+      outline: 2px solid var(--primary);
+      outline-offset: 2px;
+    }
+    .linha {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 15px;
+    }
+    .linha > div {
+      flex: 1 1 200px;
+    }
+    .botoes {
+      margin-top: 30px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    button {
+      padding: 12px 20px;
+      font-size: 16px;
+      cursor: pointer;
+      border: none;
+      border-radius: 4px;
+      background: var(--primary);
+      color: #fff;
+      transition: background 0.2s;
+    }
+    button:hover {
+      background: var(--primary-hover);
+    }
+    #resultado {
+      margin-top: 30px;
+      padding: 20px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+    }
+    #pdfFilters {
+      margin-top: 20px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 10px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    #pdfFilters label {
+      font-weight: normal;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      margin-right: 0;
+    }
+    /* ensure checkboxes don't stretch full width on small screens */
+    #pdfFilters input[type="checkbox"] {
+      width: auto;
+    }
+    #map {
+      height: 400px;
+      margin-top: 20px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+    }
+    @media (max-width: 600px) {
+      .botoes button {
+        flex: 1 1 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <h1>Cotação de Voo Executivo</h1>
+
+    <label for="aeronave">Aeronave:</label>
+    <select id="aeronave">
+      <option value="" disabled selected>Escolha uma aeronave</option>
+      <option value="Hawker 400">Hawker 400 — R$36,00/km</option>
+      <option value="Phenom 100">Phenom 100 — R$36,00/km</option>
+      <option value="Citation II">Citation II — R$36,00/km</option>
+      <option value="King Air C90">King Air C90 — R$30,00/km</option>
+      <option value="Sêneca IV">Sêneca IV — R$22,00/km</option>
+      <option value="Cirrus SR22">Cirrus SR22 — R$15,00/km</option>
+    </select>
+
+    <label for="tarifa">Tarifa por km (R$):</label>
+    <input type="number" id="tarifa" step="0.01" />
+
+    <div class="linha">
+      <div>
+        <label for="nm">Distância (NM):</label>
+        <input type="number" id="nm" />
+      </div>
+      <div>
+        <label for="km">Distância (KM):</label>
+        <input type="number" id="km" />
+      </div>
+      <div>
+        <label for="origem">Origem:</label>
+        <input type="text" id="origem" />
+      </div>
+      <div>
+        <label for="destino">Destino:</label>
+        <input type="text" id="destino" />
+      </div>
+    </div>
+
+    <div id="stops"></div>
+    <button id="addStop" type="button">Adicionar Aeroporto</button>
+
+    <div class="linha">
+      <div>
+        <label for="dataIda">Data Ida:</label>
+        <input type="date" id="dataIda" />
+      </div>
+      <div>
+        <label for="dataVolta">Data Volta:</label>
+        <input type="date" id="dataVolta" />
+      </div>
+    </div>
+
+    <label for="valorExtra">Acréscimo ou Desconto:</label>
+    <input type="number" id="valorExtra" placeholder="Valor em R$" />
+    <select id="tipoExtra">
+      <option value="soma">Adicionar</option>
+      <option value="subtrai">Subtrair</option>
+    </select>
+
+    <label for="pagamento">Dados para pagamento:</label>
+    <textarea id="pagamento" rows="5">INTER - 077
+AUTOCON SUPRIMENTOS DE INFORMATICA
+CNPJ: 36.326.772/0001-65
+Agência: 0001
+Conta: 25691815-5</textarea>
+
+    <label for="observacoes">Observações:</label>
+    <textarea id="observacoes" rows="4"></textarea>
+
+    <div id="pdfFilters">
+      <h4>Campos do PDF</h4>
+      <label><input type="checkbox" id="showRota" checked /> Rota</label>
+      <label><input type="checkbox" id="showAeronave" checked /> Aeronave</label>
+      <label><input type="checkbox" id="showTarifa" checked /> Tarifa</label>
+      <label><input type="checkbox" id="showDistancia" checked /> Distância</label>
+      <label><input type="checkbox" id="showDatas" checked /> Datas</label>
+      <label><input type="checkbox" id="showAjuste" checked /> Ajuste</label>
+      <label><input type="checkbox" id="showObservacoes" checked /> Observações</label>
+      <label><input type="checkbox" id="showPagamento" checked /> Pagamento</label>
+      <label><input type="checkbox" id="showMapa" checked /> Mapa</label>
+    </div>
+
+    <div class="botoes">
+      <button onclick="gerarPreOrcamento()">Gerar Pré-Orçamento</button>
+      <button onclick="gerarPDF()">Gerar PDF</button>
+      <button onclick="limparCampos()">Limpar</button>
+    </div>
+
+    <div id="resultado"></div>
+
+    <div id="map"></div>
+
+    <script src="app.js"></script>
+  </main>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "leandro-almeida",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test.js"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,154 @@
+const assert = require('assert');
+const { buildState, buildDocDefinition, gerarPDF } = require('./app.js');
+
+function extractText(docDef) {
+  return docDef.content
+    .map(item => {
+      if (item && item.text) return item.text;
+      if (item && item.table) {
+        return item.table.body.flat().map(c => c.text).join(' ');
+      }
+      return '';
+    })
+    .join('\n');
+}
+
+const baseState = {
+  aeronave: 'Hawker 400',
+  nm: 100,
+  origem: 'Origem',
+  destino: 'Destino',
+  dataIda: '2024-01-01',
+  dataVolta: '2024-01-02',
+  observacoes: 'Teste',
+  pagamento: 'INTER - 077\nAUTOCON SUPRIMENTOS DE INFORMATICA\nCNPJ: 36.326.772/0001-65\nAgência: 0001\nConta: 25691815-5',
+  valorExtra: 50,
+  tipoExtra: 'soma',
+  valorKm: 36,
+  showRota: true,
+  showAeronave: true,
+  showTarifa: true,
+  showDistancia: true,
+  showDatas: true,
+  showAjuste: true,
+  showObservacoes: true,
+  showPagamento: true,
+  showMapa: true
+};
+
+const expectations = {
+  showRota: 'Rota:',
+  showAeronave: 'Aeronave:',
+  showTarifa: 'Tarifa por km:',
+  showDistancia: 'Distância:',
+  showDatas: 'Datas:',
+  showAjuste: 'Outras Despesas',
+  showObservacoes: 'Observações:',
+  showPagamento: 'Dados de pagamento:',
+  showMapa: 'Mapa:'
+};
+
+for (const [flag, keyword] of Object.entries(expectations)) {
+  const state = { ...baseState, [flag]: false };
+  const doc = buildDocDefinition(state);
+  const text = extractText(doc);
+  assert(!text.includes(keyword), `${keyword} should be omitted when ${flag} is false`);
+}
+
+console.log('All filter tests passed.');
+
+// total should include adjustment even when showAjuste is false
+const stateAdjHidden = { ...baseState, valorExtra: 5000, showAjuste: false };
+const docAdjHidden = buildDocDefinition(stateAdjHidden);
+const textAdjHidden = extractText(docAdjHidden);
+const subtotal = stateAdjHidden.nm * 1.852 * stateAdjHidden.valorKm;
+const expectedTotal = (subtotal + 5000).toLocaleString('pt-BR', { minimumFractionDigits: 2 });
+assert(textAdjHidden.includes(`Total Final: R$ ${expectedTotal}`), 'Final total should include adjustment even when hidden');
+assert(textAdjHidden.includes('Total parcial'), 'Partial total should be displayed');
+console.log('Adjustment exclusion test passed.');
+
+// km -> nm conversion via buildState
+const elements = {
+  aeronave: { value: 'Hawker 400' },
+  nm: { value: '' },
+  km: { value: '185.2' },
+  origem: { value: '' },
+  destino: { value: '' },
+  dataIda: { value: '' },
+  dataVolta: { value: '' },
+  observacoes: { value: '' },
+  pagamento: { value: 'INTER - 077\nAUTOCON SUPRIMENTOS DE INFORMATICA\nCNPJ: 36.326.772/0001-65\nAgência: 0001\nConta: 25691815-5' },
+  valorExtra: { value: '0' },
+  tipoExtra: { value: 'soma' },
+  tarifa: { value: '36' },
+  showRota: { checked: true },
+  showAeronave: { checked: true },
+  showTarifa: { checked: true },
+  showDistancia: { checked: true },
+  showDatas: { checked: true },
+  showAjuste: { checked: true },
+  showObservacoes: { checked: true },
+  showPagamento: { checked: true },
+  showMapa: { checked: true }
+};
+global.document = {
+  getElementById: id => elements[id],
+  querySelectorAll: sel => (sel === '.stop-input' ? [{ value: 'SBBH' }] : [])
+};
+const stateConv = buildState();
+assert(Math.abs(stateConv.nm - 100) < 1e-6, 'KM field should convert to NM');
+console.log('KM to NM conversion test passed.');
+assert.deepStrictEqual(stateConv.stops, ['SBBH'], 'Stops should include dynamically added airports');
+console.log('Stops collection test passed.');
+
+// tariff field respects manual override
+elements.tarifa.value = '50';
+const stateTar = buildState();
+assert.strictEqual(stateTar.valorKm, 50, 'Tariff input should override default');
+elements.tarifa.value = '';
+const stateTarFallback = buildState();
+assert.strictEqual(stateTarFallback.valorKm, 36, 'Empty tariff reverts to default');
+console.log('Tariff override test passed.');
+
+// custom tariff affects total
+const customDoc = buildDocDefinition({ ...baseState, valorKm: 50 });
+const textCustom = extractText(customDoc);
+assert(textCustom.includes('R$ 9.310,00'), 'Custom tariff should affect total');
+console.log('Custom tariff test passed.');
+
+// route order should place destination first then extra stops
+const routeDoc = buildDocDefinition({
+  ...baseState,
+  origem: 'SBBR',
+  destino: 'SBMO',
+  stops: ['SBBH', 'SBBR']
+});
+const routeText = extractText(routeDoc);
+assert(routeText.includes('SBBR → SBMO → SBBH → SBBR'), 'Route should list destination before extra stops');
+console.log('Route ordering test passed.');
+
+// gerarPDF should request coordinates in correct order
+(async () => {
+  const fetchCalls = [];
+  global.fetch = async (url) => {
+    fetchCalls.push(url);
+    return { ok: true, json: async () => ({ location: { lat: 0, lon: 0 } }) };
+  };
+  await gerarPDF({
+    ...baseState,
+    origem: 'SBBR',
+    destino: 'SBMO',
+    stops: ['SBBH', 'SBBR'],
+    showMapa: true,
+    showRota: false,
+    showAeronave: false,
+    showTarifa: false,
+    showDistancia: false,
+    showDatas: false,
+    showAjuste: false,
+    showObservacoes: false,
+  });
+  const codes = fetchCalls.map(u => u.split('/').pop());
+  assert.deepStrictEqual(codes, ['SBBR', 'SBMO', 'SBBH', 'SBBR'], 'gerarPDF should fetch coordinates in waypoint order');
+  console.log('gerarPDF waypoint order test passed.');
+})();


### PR DESCRIPTION
## Summary
- prevent PDF filter checkboxes from stretching to full width on small screens to keep labels aligned

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0925a8c54832f8350f351d25b4168