### PR TITLE
Add executive flight quotation web app with testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and insert your RapidAPI Aerodatabox key
+AERODATABOX_KEY=YOUR_RAPIDAPI_KEY_HERE

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+vendor/
+.env

--- a/app.js
+++ b/app.js
@@ -1,0 +1,268 @@
+const valoresKm = {
+  "Hawker 400": 36,
+  "Phenom 100": 36,
+  "Citation II": 36,
+  "King Air C90": 30,
+  "Sêneca IV": 22,
+  "Cirrus SR22": 15
+};
+
+let map;
+let routeLayer = null;
+
+if (typeof document !== 'undefined') {
+  const nmInput = document.getElementById('nm');
+  const kmInput = document.getElementById('km');
+  if (nmInput && kmInput) {
+    nmInput.addEventListener('input', e => {
+      const val = parseFloat(e.target.value);
+      kmInput.value = Number.isFinite(val) ? (val * 1.852).toFixed(1) : '';
+    });
+    kmInput.addEventListener('input', e => {
+      const val = parseFloat(e.target.value);
+      nmInput.value = Number.isFinite(val) ? (val / 1.852).toFixed(1) : '';
+    });
+  }
+
+  const aeronaveSel = document.getElementById('aeronave');
+  const tarifaInput = document.getElementById('tarifa');
+  if (aeronaveSel && tarifaInput) {
+    aeronaveSel.addEventListener('change', () => {
+      tarifaInput.value = valoresKm[aeronaveSel.value] || '';
+    });
+  }
+
+  const addStop = document.getElementById('addStop');
+  if (addStop) {
+    addStop.addEventListener('click', () => {
+      const div = document.createElement('div');
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.className = 'stop-input';
+      input.placeholder = 'Aeroporto';
+      div.appendChild(input);
+      document.getElementById('stops').appendChild(div);
+    });
+  }
+
+  if (typeof L !== 'undefined' && document.getElementById('map')) {
+    map = L.map('map').setView([0, 0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+  }
+}
+
+function haversine(a, b) {
+  const R = 6371; // km
+  const toRad = deg => deg * Math.PI / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+function updateDistanceFromAirports(waypoints) {
+  const nmInput = typeof document !== 'undefined' ? document.getElementById('nm') : null;
+  const kmInput = typeof document !== 'undefined' ? document.getElementById('km') : null;
+  const points = (waypoints || []).filter(p => p && Number.isFinite(p.lat) && Number.isFinite(p.lng));
+
+  if (points.length < 2) {
+    if (routeLayer && typeof routeLayer.remove === 'function') routeLayer.remove();
+    routeLayer = null;
+    if (nmInput) nmInput.value = '';
+    if (kmInput) kmInput.value = '';
+    return;
+  }
+
+  let kmTotal = 0;
+  for (let i = 1; i < points.length; i++) {
+    kmTotal += haversine(points[i - 1], points[i]);
+  }
+  const nmTotal = kmTotal / 1.852;
+
+  if (nmInput) nmInput.value = nmTotal.toFixed(1);
+  if (kmInput) kmInput.value = kmTotal.toFixed(1);
+
+  if (typeof L !== 'undefined' && map) {
+    if (routeLayer) routeLayer.remove();
+    routeLayer = L.polyline(points.map(p => [p.lat, p.lng]), { color: 'blue' }).addTo(map);
+    map.fitBounds(routeLayer.getBounds());
+  }
+}
+
+function buildState() {
+  const aeronave = document.getElementById('aeronave').value;
+  const nmField = document.getElementById('nm');
+  const kmField = document.getElementById('km');
+  let nm = parseFloat(nmField.value);
+  const kmVal = parseFloat(kmField.value);
+  if (!Number.isFinite(nm) && Number.isFinite(kmVal)) {
+    nm = kmVal / 1.852;
+  }
+  const origem = document.getElementById('origem').value;
+  const destino = document.getElementById('destino').value;
+  const dataIda = document.getElementById('dataIda').value;
+  const dataVolta = document.getElementById('dataVolta').value;
+  const observacoes = document.getElementById('observacoes').value;
+  const pagamentoEl = document.getElementById('pagamento');
+  const pagamento = pagamentoEl ? pagamentoEl.value : '';
+  const valorExtra = parseFloat(document.getElementById('valorExtra').value) || 0;
+  const tipoExtra = document.getElementById('tipoExtra').value;
+  const tarifaVal = parseFloat(document.getElementById('tarifa').value);
+  const valorKm = Number.isFinite(tarifaVal) ? tarifaVal : valoresKm[aeronave];
+  const stops = Array.from(document.querySelectorAll('.stop-input')).map(i => i.value).filter(Boolean);
+
+  return {
+    aeronave,
+    nm,
+    origem,
+    destino,
+    dataIda,
+    dataVolta,
+    observacoes,
+    pagamento,
+    valorExtra,
+    tipoExtra,
+    valorKm,
+    stops,
+    showRota: document.getElementById('showRota').checked,
+    showAeronave: document.getElementById('showAeronave').checked,
+    showTarifa: document.getElementById('showTarifa').checked,
+    showDistancia: document.getElementById('showDistancia').checked,
+    showDatas: document.getElementById('showDatas').checked,
+    showAjuste: document.getElementById('showAjuste').checked,
+    showObservacoes: document.getElementById('showObservacoes').checked,
+    showPagamento: document.getElementById('showPagamento').checked,
+    showMapa: document.getElementById('showMapa').checked
+  };
+}
+
+function buildDocDefinition(state) {
+  const km = state.nm * 1.852;
+  const subtotal = km * state.valorKm;
+  let total = subtotal;
+  if (state.valorExtra > 0) {
+    if (state.tipoExtra === 'soma') total += state.valorExtra; else total -= state.valorExtra;
+  }
+
+  const content = [{ text: 'Cotação de Voo Executivo', style: 'header' }];
+
+  if (state.showRota) {
+    const codes = [state.origem, state.destino, ...(state.stops || [])];
+    content.push({ text: `Rota: ${codes.filter(Boolean).join(' → ')}` });
+  }
+  if (state.showAeronave) {
+    content.push({ text: `Aeronave: ${state.aeronave}` });
+  }
+  if (state.showTarifa) {
+    content.push({ text: `Tarifa por km: R$ ${state.valorKm.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}` });
+  }
+  if (state.showDistancia) {
+    content.push({ text: `Distância: ${state.nm} NM (${km.toFixed(1)} km)` });
+  }
+  if (state.showDatas) {
+    content.push({ text: `Datas: ${state.dataIda} - ${state.dataVolta}` });
+  }
+
+  content.push({ text: `Total parcial: R$ ${subtotal.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}` });
+
+  if (state.showAjuste && state.valorExtra > 0) {
+    const label = state.tipoExtra === 'soma' ? 'Outras Despesas' : 'Desconto';
+    content.push({ text: `${label}: R$ ${state.valorExtra.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}` });
+  }
+
+  content.push({ text: `Total Final: R$ ${total.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}` });
+
+  if (state.showObservacoes && state.observacoes) {
+    content.push({ text: `Observações: ${state.observacoes}` });
+  }
+  if (state.showPagamento && state.pagamento) {
+    content.push({ text: `Dados de pagamento: ${state.pagamento}` });
+  }
+  if (state.showMapa) {
+    content.push({ text: 'Mapa:' });
+  }
+
+  return { content };
+}
+
+async function gerarPreOrcamento() {
+  const state = buildState();
+  const km = state.nm * 1.852;
+  const subtotal = km * state.valorKm;
+  let total = subtotal;
+  let labelExtra = '';
+  if (state.valorExtra > 0) {
+    if (state.tipoExtra === 'soma') {
+      total += state.valorExtra;
+      labelExtra = `+ R$ ${state.valorExtra.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`;
+    } else {
+      total -= state.valorExtra;
+      labelExtra = `- R$ ${state.valorExtra.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`;
+    }
+  }
+  const resultado = document.getElementById('resultado');
+  resultado.innerHTML = `
+    <h3>Pré-Orçamento</h3>
+    <p><strong>Origem:</strong> ${state.origem}</p>
+    <p><strong>Destino:</strong> ${state.destino}</p>
+    <p><strong>Aeronave:</strong> ${state.aeronave}</p>
+    <p><strong>Distância:</strong> ${state.nm} NM (${km.toFixed(1)} km)</p>
+    ${state.valorExtra > 0 ? `<p><strong>Ajuste:</strong> ${labelExtra}</p>` : ''}
+    <p><strong>Total Estimado:</strong> R$ ${total.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</p>
+  `;
+}
+
+async function gerarPDF(state) {
+  const s = state || buildState();
+  let waypoints = [];
+  if (s.showMapa) {
+    const codes = [s.origem, s.destino, ...(s.stops || [])];
+    for (const code of codes) {
+      const res = await fetch(`https://aerodatabox.p.rapidapi.com/airports/icao/${code}`);
+      const data = await res.json();
+      if (data && data.location) waypoints.push({ lat: data.location.lat, lng: data.location.lon });
+    }
+    updateDistanceFromAirports(waypoints);
+  }
+  const docDefinition = buildDocDefinition(s);
+  if (typeof pdfMake !== 'undefined') {
+    pdfMake.createPdf(docDefinition).open();
+  }
+  return docDefinition;
+}
+
+function limparCampos() {
+  if (typeof document === 'undefined') return;
+  document.querySelectorAll('input, textarea').forEach(el => {
+    if (el.type === 'checkbox') el.checked = false;
+    else el.value = '';
+  });
+  document.getElementById('tarifa').value = '';
+  document.getElementById('showRota').checked = true;
+  document.getElementById('showAeronave').checked = true;
+  document.getElementById('showTarifa').checked = true;
+  document.getElementById('showDistancia').checked = true;
+  document.getElementById('showDatas').checked = true;
+  document.getElementById('showAjuste').checked = true;
+  document.getElementById('showObservacoes').checked = true;
+  document.getElementById('showPagamento').checked = true;
+  document.getElementById('showMapa').checked = true;
+  document.getElementById('resultado').innerHTML = '';
+  if (routeLayer && routeLayer.remove) routeLayer.remove();
+}
+
+if (typeof window !== 'undefined') {
+  window.buildState = buildState;
+  window.buildDocDefinition = buildDocDefinition;
+  window.gerarPreOrcamento = gerarPreOrcamento;
+  window.gerarPDF = gerarPDF;
+  window.limparCampos = limparCampos;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { buildState, buildDocDefinition, gerarPDF };
+}

--- a/cotacao.js
+++ b/cotacao.js
@@ -1,0 +1,9 @@
+function valorParcial(distanciaKm, valorKm) {
+  return distanciaKm * valorKm;
+}
+
+function valorTotal(distanciaKm, valorKm, valorExtra = 0) {
+  return valorParcial(distanciaKm, valorKm) + valorExtra;
+}
+
+module.exports = { valorParcial, valorTotal };

--- a/index.html
+++ b/index.html
@@ -1,14 +1,3 @@
-Cotação de voo executivo web app com conversão NM↔KM, múltiplas pernas, mapa Leaflet e lookup de aeroportos via Aerodatabox.
-# Leandro-Almeida
-
-To regenerate the vendored jsdom tarball, run:
-
-```
-npm pack jsdom@24.0.0
-mkdir -p vendor
-mv jsdom-24.0.0.tgz vendor/
-```
-
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "leandro-almeida",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test.js"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,154 @@
+const assert = require('assert');
+const { buildState, buildDocDefinition, gerarPDF } = require('./app.js');
+
+function extractText(docDef) {
+  return docDef.content
+    .map(item => {
+      if (item && item.text) return item.text;
+      if (item && item.table) {
+        return item.table.body.flat().map(c => c.text).join(' ');
+      }
+      return '';
+    })
+    .join('\n');
+}
+
+const baseState = {
+  aeronave: 'Hawker 400',
+  nm: 100,
+  origem: 'Origem',
+  destino: 'Destino',
+  dataIda: '2024-01-01',
+  dataVolta: '2024-01-02',
+  observacoes: 'Teste',
+  pagamento: 'INTER - 077\nAUTOCON SUPRIMENTOS DE INFORMATICA\nCNPJ: 36.326.772/0001-65\nAgência: 0001\nConta: 25691815-5',
+  valorExtra: 50,
+  tipoExtra: 'soma',
+  valorKm: 36,
+  showRota: true,
+  showAeronave: true,
+  showTarifa: true,
+  showDistancia: true,
+  showDatas: true,
+  showAjuste: true,
+  showObservacoes: true,
+  showPagamento: true,
+  showMapa: true
+};
+
+const expectations = {
+  showRota: 'Rota:',
+  showAeronave: 'Aeronave:',
+  showTarifa: 'Tarifa por km:',
+  showDistancia: 'Distância:',
+  showDatas: 'Datas:',
+  showAjuste: 'Outras Despesas',
+  showObservacoes: 'Observações:',
+  showPagamento: 'Dados de pagamento:',
+  showMapa: 'Mapa:'
+};
+
+for (const [flag, keyword] of Object.entries(expectations)) {
+  const state = { ...baseState, [flag]: false };
+  const doc = buildDocDefinition(state);
+  const text = extractText(doc);
+  assert(!text.includes(keyword), `${keyword} should be omitted when ${flag} is false`);
+}
+
+console.log('All filter tests passed.');
+
+// total should include adjustment even when showAjuste is false
+const stateAdjHidden = { ...baseState, valorExtra: 5000, showAjuste: false };
+const docAdjHidden = buildDocDefinition(stateAdjHidden);
+const textAdjHidden = extractText(docAdjHidden);
+const subtotal = stateAdjHidden.nm * 1.852 * stateAdjHidden.valorKm;
+const expectedTotal = (subtotal + 5000).toLocaleString('pt-BR', { minimumFractionDigits: 2 });
+assert(textAdjHidden.includes(`Total Final: R$ ${expectedTotal}`), 'Final total should include adjustment even when hidden');
+assert(textAdjHidden.includes('Total parcial'), 'Partial total should be displayed');
+console.log('Adjustment exclusion test passed.');
+
+// km -> nm conversion via buildState
+const elements = {
+  aeronave: { value: 'Hawker 400' },
+  nm: { value: '' },
+  km: { value: '185.2' },
+  origem: { value: '' },
+  destino: { value: '' },
+  dataIda: { value: '' },
+  dataVolta: { value: '' },
+  observacoes: { value: '' },
+  pagamento: { value: 'INTER - 077\nAUTOCON SUPRIMENTOS DE INFORMATICA\nCNPJ: 36.326.772/0001-65\nAgência: 0001\nConta: 25691815-5' },
+  valorExtra: { value: '0' },
+  tipoExtra: { value: 'soma' },
+  tarifa: { value: '36' },
+  showRota: { checked: true },
+  showAeronave: { checked: true },
+  showTarifa: { checked: true },
+  showDistancia: { checked: true },
+  showDatas: { checked: true },
+  showAjuste: { checked: true },
+  showObservacoes: { checked: true },
+  showPagamento: { checked: true },
+  showMapa: { checked: true }
+};
+global.document = {
+  getElementById: id => elements[id],
+  querySelectorAll: sel => (sel === '.stop-input' ? [{ value: 'SBBH' }] : [])
+};
+const stateConv = buildState();
+assert(Math.abs(stateConv.nm - 100) < 1e-6, 'KM field should convert to NM');
+console.log('KM to NM conversion test passed.');
+assert.deepStrictEqual(stateConv.stops, ['SBBH'], 'Stops should include dynamically added airports');
+console.log('Stops collection test passed.');
+
+// tariff field respects manual override
+elements.tarifa.value = '50';
+const stateTar = buildState();
+assert.strictEqual(stateTar.valorKm, 50, 'Tariff input should override default');
+elements.tarifa.value = '';
+const stateTarFallback = buildState();
+assert.strictEqual(stateTarFallback.valorKm, 36, 'Empty tariff reverts to default');
+console.log('Tariff override test passed.');
+
+// custom tariff affects total
+const customDoc = buildDocDefinition({ ...baseState, valorKm: 50 });
+const textCustom = extractText(customDoc);
+assert(textCustom.includes('R$ 9.310,00'), 'Custom tariff should affect total');
+console.log('Custom tariff test passed.');
+
+// route order should place destination first then extra stops
+const routeDoc = buildDocDefinition({
+  ...baseState,
+  origem: 'SBBR',
+  destino: 'SBMO',
+  stops: ['SBBH', 'SBBR']
+});
+const routeText = extractText(routeDoc);
+assert(routeText.includes('SBBR → SBMO → SBBH → SBBR'), 'Route should list destination before extra stops');
+console.log('Route ordering test passed.');
+
+// gerarPDF should request coordinates in correct order
+(async () => {
+  const fetchCalls = [];
+  global.fetch = async (url) => {
+    fetchCalls.push(url);
+    return { ok: true, json: async () => ({ location: { lat: 0, lon: 0 } }) };
+  };
+  await gerarPDF({
+    ...baseState,
+    origem: 'SBBR',
+    destino: 'SBMO',
+    stops: ['SBBH', 'SBBR'],
+    showMapa: true,
+    showRota: false,
+    showAeronave: false,
+    showTarifa: false,
+    showDistancia: false,
+    showDatas: false,
+    showAjuste: false,
+    showObservacoes: false,
+  });
+  const codes = fetchCalls.map(u => u.split('/').pop());
+  assert.deepStrictEqual(codes, ['SBBR', 'SBMO', 'SBBH', 'SBBR'], 'gerarPDF should fetch coordinates in waypoint order');
+  console.log('gerarPDF waypoint order test passed.');
+})();


### PR DESCRIPTION
## Summary
- Add environment and ignore configs
- Implement flight quotation UI with distance conversion, multi-leg routing, and PDF export
- Include utility functions and tests for PDF field filtering and route ordering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a83ffee164832fa7e3edc4af0d0774